### PR TITLE
fix countIn button status and add upload support of .gp extension

### DIFF
--- a/src/alphatab-full.js
+++ b/src/alphatab-full.js
@@ -503,7 +503,7 @@ class PlayerControlsGroup extends React.Component {
     e.preventDefault();
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = ".gp3,.gp4,.gp5,.gpx,.musicxml,.mxml,.xml,.capx";
+    input.accept = ".gp,.gp3,.gp4,.gp5,.gpx,.musicxml,.mxml,.xml,.capx";
     input.onchange = () => {
       if (input.files.length === 1) {
         this.openFile(input.files[0]);

--- a/src/alphatab-full.js
+++ b/src/alphatab-full.js
@@ -646,7 +646,7 @@ class PlayerControlsGroup extends React.Component {
               className={
                 "at-count-in" +
                 (this.props.api?.isReadyForPlayback ? "" : " disabled") +
-                (this.state.isMetronomeActive ? " active" : "")
+                (this.state.isCountInActive ? " active" : "")
               }
               data-toggle="tooltip"
               data-placement="top"


### PR DESCRIPTION
CountIn button status not correct, and it's actually mixed with "isMetronomeActive" status. So it's a minor fix, just replace "isMetronomeActive" with "isCountInActive".
Most guitar pro 7 file extension is .gp, but there is no .gp extension in upload accept file extension list, so i just added it in the list, hope this fix can make it easier for someone to try the upload function.