### PR TITLE
Docs text fixes

### DIFF
--- a/docs/alphatex/bar-metadata.mdx
+++ b/docs/alphatex/bar-metadata.mdx
@@ -20,7 +20,7 @@ Time signatures have the format `\ts Numerator Denominator`
 ## Repeats
 
 Repeats can be started with `\ro` and 
-be closed with `\rc Count`. Count specifies how often
+be closed with `\rc Count`. Count specifies how many times
 the bar range is repeated. 
 
 <AlphaTexSample>{`

--- a/docs/alphatex/beat-effects.mdx
+++ b/docs/alphatex/beat-effects.mdx
@@ -6,7 +6,7 @@ import AlphaTexSample from '../../src/alphatex-sample';
 
 There are various effects that can be applied to a beat. All beat
 effects are specified in braces after the beat. 
-`Beat{Effects}` Multiple effects are simple separated by spaces like `3.3 {f v}`
+`Beat{Effects}` Multiple effects are simply separated by spaces like `3.3 {f v}`
 
 ## Simple Effects
 
@@ -60,8 +60,8 @@ Dynamics are beat effects with the indicator `dy` followed by one of the support
 
 ## Tuplet Ranges
 
-You can also specify the the tuplet as part of a ranged duration. This makes writing tuplets a bit easier if there are many.
-To reset the tuplet simply a new duration range can be started. For individual notes other tuplets can be specified too.
+You can also specify the tuplet as part of a ranged duration. This makes writing tuplets a bit easier if there are many.
+To reset the tuplet range, a new duration range can be started. For individual notes other tuplets can be specified too.
 1 can be used to specify no tuplet while a tuplet range is active. 
 
 <AlphaTexSample>{`

--- a/docs/alphatex/note-effects.mdx
+++ b/docs/alphatex/note-effects.mdx
@@ -65,6 +65,14 @@ x.3{psu} 3.3 |
 3.3{g}
 `}</AlphaTexSample>
 
+### Dead Notes
+
+Dead Notes are notated by using `x` as fret. 
+
+<AlphaTexSample>{`
+3.3{x} x.3
+`}</AlphaTexSample>
+
 ### Accentuations
 
 normal `ac` and heavy `hac`
@@ -124,15 +132,6 @@ For stringed instruments the fret simply can be set to `-` and the note will be 
 `}</AlphaTexSample>
 
 For non stringed instrument it can be a bit more tricky as we cannot use the string to identify which note to tie. There are multiple ways to work around this problem. AlphaTab will try to find the start note for the tie via several rules, if this does not match the desired behavior, you can specify the note value as alternative and indicate the tie via a note effect.
-
-# Dead Notes
-
-Dead Notes are notated by using `x` as fret. 
-
-<AlphaTexSample>{`
-3.3{x} x.3
-`}</AlphaTexSample>
-
 
 <AlphaTexSample>{`
 \\tuning piano

--- a/docs/alphatex/notes.mdx
+++ b/docs/alphatex/notes.mdx
@@ -4,7 +4,7 @@ title: Notes
 
 import AlphaTexSample from '../../src/alphatex-sample';
 
-The following examples show how to general notes. Multiple bars are
+The following examples show how to write general notes. Multiple bars are
 separated by `|`.
 
 ## Single notes and rests
@@ -20,7 +20,7 @@ as a number where 1 represents a full note, 2 a half note and so on.
 
 ## Chords
 
-To specify multiple notes on a beat, group them in parenthesis. The full format is
+To specify multiple notes on a beat, group them in parentheses. The full format is
 `(fret.string fret.string ...).duration`
 
 <AlphaTexSample>{`

--- a/docs/showcase/effects.mdx
+++ b/docs/showcase/effects.mdx
@@ -26,7 +26,7 @@ Beat vibrators and note vibratos are both available.
 <AlphaTab file="/files/features/Vibrato.gp5" />
 
 ## Dynamics
-From piano pianissimo to forte fortissimo, they are all there
+From piano pianissimo to forte fortissimo, they are all there.
 <AlphaTab file="/files/features/Dynamics.gp5" />
 
 ## Tap/Slap/Pop
@@ -51,7 +51,7 @@ String bendings can be rendered by alphaTab as well.
 <AlphaTab file="/files/features/Bends.gp" />
 
 ## Whammy Bar
-A lot of electrical guitars come with whammy bars. alphaTab show whammy bar effects. 
+A lot of electrical guitars come with whammy bars. alphaTab shows whammy bar effects. 
 <AlphaTab file="/files/features/Whammy.gp" />
 
 ## Tremolo Picking

--- a/docs/showcase/special-notes.mdx
+++ b/docs/showcase/special-notes.mdx
@@ -19,5 +19,5 @@ they are played by hitting the string without pressing but with touching the fin
 <AlphaTab file="/files/features/DeadNotes.gp5" />
 
 ## Ghost Notes
-Ghost notes are played more slient than normal notes.
+Ghost notes are played more silently than normal notes.
 <AlphaTab file="/files/features/GhostNotes.gp5" />


### PR DESCRIPTION
Fixed header for and moved 'Dead notes' of alphaTex up to 'Ghost notes'. The rest is just text fixes.