### PR TITLE
fix(Loop): make sure loop is working in playground

### DIFF
--- a/src/components/AlphaTabPlayground/playground-settings.tsx
+++ b/src/components/AlphaTabPlayground/playground-settings.tsx
@@ -373,7 +373,7 @@ function buildSettingsGroups(): SettingsGroupSchema[] {
                 },
                 {
                     label: 'Looping',
-                    ...factory.apiAccessors('looping'),
+                    ...factory.apiAccessors('isLooping'),
                     control: { type: 'boolean-toggle' }
                 },
                 factory.enumDropDown('Player Mode', 'player.playerMode', alphaTab.PlayerMode, noRerender),


### PR DESCRIPTION
It seems that the playground is trying to set a loop, but it only works when we use the `isLooping`.

It appears that the playground button when toggling **Looping**, but it only functions correctly when we use `isLooping`. This PR addresses the bug by replacing `api.looping` with `api.isLooping`, which does work