### PR TITLE
Define alternative fonts to "Noto Sans" to support old browsers

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -41,7 +41,7 @@
   --ifm-z-index-fixed: 2000;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.2);
 
-  --ifm-font-family-base: "Noto Sans";
+  --ifm-font-family-base: "Noto Sans", Arial, Helvetica, sans-serif;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -38,22 +38,25 @@ function setAlphaTabColors(settings: alphaTab.Settings, colorMode: ColorMode) {
       
     setAlphaTabColors(settings, colorMode);
 
-    settings.display.resources.copyrightFont.families = ["Noto Sans"];
-    settings.display.resources.titleFont.families = ["Noto Serif"];
-    settings.display.resources.subTitleFont.families = ["Noto Serif"];
-    settings.display.resources.wordsFont.families = ["Noto Serif"];
-    settings.display.resources.effectFont.families = ["Noto Serif"];
-    settings.display.resources.timerFont.families = ["Noto Serif"];
-    settings.display.resources.fretboardNumberFont.families = ["Noto Sans"];
-    settings.display.resources.tablatureFont.families = ["Noto Sans"];
-    settings.display.resources.graceFont.families = ["Noto Sans"];
-    settings.display.resources.barNumberFont.families = ["Noto Sans"];
-    settings.display.resources.fingeringFont.families = ["Noto Serif"];
-    settings.display.resources.inlineFingeringFont.families = ["Noto Serif"];
-    settings.display.resources.markerFont.families = ["Noto Serif"];
-    settings.display.resources.directionsFont.families = ["Noto Serif"];
-    settings.display.resources.numberedNotationFont.families = ["Noto Sans"];
-    settings.display.resources.numberedNotationGraceFont.families = ["Noto Sans"];
+    const sansStack = ["Noto Sans", "Arial", "Helvetica", "sans-serif"];
+    const serifStack = ["Noto Serif", "Georgia", "Times New Roman", "serif"];
+
+    settings.display.resources.copyrightFont.families = sansStack;
+    settings.display.resources.titleFont.families = serifStack;
+    settings.display.resources.subTitleFont.families = serifStack;
+    settings.display.resources.wordsFont.families = serifStack;
+    settings.display.resources.effectFont.families = serifStack;
+    settings.display.resources.timerFont.families = serifStack;
+    settings.display.resources.fretboardNumberFont.families = sansStack;
+    settings.display.resources.tablatureFont.families = sansStack;
+    settings.display.resources.graceFont.families = sansStack;
+    settings.display.resources.barNumberFont.families = sansStack;
+    settings.display.resources.fingeringFont.families = serifStack;
+    settings.display.resources.inlineFingeringFont.families = serifStack;
+    settings.display.resources.markerFont.families = serifStack;
+    settings.display.resources.directionsFont.families = serifStack;
+    settings.display.resources.numberedNotationFont.families = sansStack;
+    settings.display.resources.numberedNotationGraceFont.families = sansStack;
 }
 
 export default {


### PR DESCRIPTION
Hi @Danielku15,

This PR adds support for any device that doesn't have `Noto Sans`, or had issues loading it somehow.
For context, here is the reason I raised that PR.

I was having issues loading the alphatab notation on an old laptop, even though the audio was playing fine.
It's an old MacBook Air (maybe 2012) with High Sierra 10.13 32-bit (x86_64), which has an old Chrome 116.0.5845.187 x84_64. Probably the latest they had supported for x86.

<img width="736" height="337" alt="chrome-116x86" src="https://github.com/user-attachments/assets/26e9f1d1-9589-4a97-9c93-2bb2ce72ce78" />



Anyway, I decided to debug that, and it was an easy fix.
The logs had the following error:

> `[AlphaTab][Font] [Noto Serif] Loading Failed, rendering cannot start Font not available`
<img width="1366" height="768" alt="noto-sans-error" src="https://github.com/user-attachments/assets/db672cbb-9cbd-4d23-a5dc-d817569dd3ed" />


As a workaround, I installed Noto Sans, and I got the same error for Noto Serif, and weird enough, I might not have installed the correct one, but I got the same error now for `Noto Serif`.

So instead, I decided to try fixing by adding alternative fonts as a fallback, and now it's working fine 🎉 

It might look slightly different on some of the fonts, but it's still very good usage.
See an example here:

<img width="1478" height="857" alt="fixed" src="https://github.com/user-attachments/assets/35383c1e-2698-442a-9fe6-930fec9e9f19" />
