### PR TITLE
feat: add print button to PlaygroundSettings

### DIFF
--- a/src/components/AlphaTabPlayground/playground-settings.tsx
+++ b/src/components/AlphaTabPlayground/playground-settings.tsx
@@ -858,6 +858,15 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({ api, isO
                     <button
                         type="button"
                         onClick={() => {
+                            api.print()
+                        }}
+                        className="button button--sm button--secondary">
+                        Print
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={() => {
                             api.downloadMidi();
                         }}
                         className="button button--sm button--secondary">


### PR DESCRIPTION
I think it would be really helpful to have "print" as one of the tools in the Playground.

<img width="474" height="928" alt="Screen Shot 2026-03-07 at 12 54 10 PM" src="https://github.com/user-attachments/assets/b09cd412-0671-4e02-b0b5-b9f75e51a62c" />

Amazing tool/library!